### PR TITLE
Remove fragment's trailing blank lines

### DIFF
--- a/lib/api_doc_updater.dart
+++ b/lib/api_doc_updater.dart
@@ -115,7 +115,7 @@ class ApiDocUpdater {
     try {
       final result = new File(fullPath).readAsStringSync().split(_eol);
       // All excerpts are [_eol] terminated, so drop the last blank line
-      if (result.length > 0 && result.last == '') result.removeLast();
+      while (result.length > 0 && result.last == '') result.removeLast();
       return result;
     } on FileSystemException catch (e) {
       stderr.writeln(

--- a/test/main.dart
+++ b/test/main.dart
@@ -71,7 +71,7 @@ void main() {
       var fragPath = p.join(apiDocUpdater.fragmentPathPrefix,
           'frag_with_trailing_whitespace.dart.txt');
       var frag = _readFile(fragPath);
-      expect(frag.endsWith('\t \n'), isTrue);
+      expect(frag.endsWith('\t \n\n'), isTrue);
     });
 
     _stdFileTest('trim.dart');

--- a/test_data/frag/frag_with_trailing_whitespace.dart.txt
+++ b/test_data/frag/frag_with_trailing_whitespace.dart.txt
@@ -1,3 +1,4 @@
 // The const declaration line ends with: TAB SPACE
 // (Beware: some editors trim out trailing whitespace!)
 const c = 1;	 
+


### PR DESCRIPTION
The tool used to remove the last line if it was blank. Now it removes as all trailing blank lines.